### PR TITLE
removing trailing DIRECTORY_SEPARATOR to be able to check single files

### DIFF
--- a/src/Spryker/Zed/Development/Business/CodeStyleSniffer/CodeStyleSniffer.php
+++ b/src/Spryker/Zed/Development/Business/CodeStyleSniffer/CodeStyleSniffer.php
@@ -83,7 +83,7 @@ class CodeStyleSniffer
      */
     protected function resolvePath($module, $namespace = null, $path = null)
     {
-        $path = $path !== null ? trim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR : null;
+        $path = $path !== null ? trim($path, DIRECTORY_SEPARATOR) : null;
 
         if ($namespace) {
             if ($module === 'all') {


### PR DESCRIPTION
Hello, I would like to suggest a change to be able to let CodeStyleSniffer check single files and not only folders. 