### PR TITLE
ignore '_after' method name in phpmd CamelCaseMethodName rule

### DIFF
--- a/src/Spryker/Zed/Development/Business/PhpMd/Rules/Controversial/CamelCaseMethodName.php
+++ b/src/Spryker/Zed/Development/Business/PhpMd/Rules/Controversial/CamelCaseMethodName.php
@@ -44,7 +44,7 @@ class CamelCaseMethodName extends AbstractRule implements MethodAware
         '_beforeStep',
         '_afterStep',
         '_before',
-        '_before',
+        '_after',
         '_depends',
         '_inject',
     ];


### PR DESCRIPTION
## PR Description

- add `_after` to the list of ignored methods, validated by the phpmd CamelCaseMethodName rule.
- remove duplicated `_before` from the list of ignored methods, validated by the phpmd CamelCaseMethodName rule.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
