### PR TITLE
Add all project namespaces as autocompletion sources

### DIFF
--- a/contribution-license-agreement.txt
+++ b/contribution-license-agreement.txt
@@ -1,0 +1,1 @@
+I hereby agree to Spryker's Contribution License Agreement in https://github.com/spryker/development/blob/ec4ff59bec30184a05e5f8f2202575c25f56bb80/CONTRIBUTING.md.

--- a/src/Spryker/Zed/Development/DevelopmentConfig.php
+++ b/src/Spryker/Zed/Development/DevelopmentConfig.php
@@ -667,12 +667,17 @@ class DevelopmentConfig extends AbstractBundleConfig
      *
      * @return array<string, string>
      */
-    public function getIdeAutoCompletionSourceDirectoryGlobPatterns()
+    public function getIdeAutoCompletionSourceDirectoryGlobPatterns(): array
     {
-        return [
+        $patterns = [
             APPLICATION_VENDOR_DIR . '/*/*/src/' => '*/*/',
-            APPLICATION_SOURCE_DIR . '/' => $this->get(KernelConstants::PROJECT_NAMESPACE) . '/*/',
         ];
+
+        foreach ($this->get(KernelConstants::PROJECT_NAMESPACES, []) as $projectNamespace) {
+            $patterns[APPLICATION_SOURCE_DIR . '/' . $projectNamespace . '/'] = '*/';
+        }
+
+        return $patterns;
     }
 
     /**

--- a/tests/SprykerTest/Zed/Development/Business/DevelopmentConfigTest.php
+++ b/tests/SprykerTest/Zed/Development/Business/DevelopmentConfigTest.php
@@ -1,0 +1,162 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerTest\Zed\Development\Business;
+
+use PHPUnit\Framework\TestCase;
+use Spryker\Shared\Kernel\KernelConstants;
+use Spryker\Zed\Development\DevelopmentConfig;
+
+/**
+ * Auto-generated group annotations
+ *
+ * @group SprykerTest
+ * @group Zed
+ * @group Development
+ * @group Business
+ * @group DevelopmentConfigTest
+ * Add your own group annotations below this line
+ */
+class DevelopmentConfigTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    protected const NAMESPACE_PYZ = 'Pyz';
+
+    /**
+     * @var string
+     */
+    protected const NAMESPACE_SPRYKER_ACADEMY = 'SprykerAcademy';
+
+    /**
+     * @var string
+     */
+    protected const NAMESPACE_CUSTOM_PROJECT = 'CustomProject';
+
+    /**
+     * @return void
+     */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        if (!defined('APPLICATION_ROOT_DIR')) {
+            define('APPLICATION_ROOT_DIR', sys_get_temp_dir());
+        }
+        if (!defined('APPLICATION_VENDOR_DIR')) {
+            define('APPLICATION_VENDOR_DIR', sys_get_temp_dir() . '/vendor');
+        }
+        if (!defined('APPLICATION_SOURCE_DIR')) {
+            define('APPLICATION_SOURCE_DIR', sys_get_temp_dir() . '/src');
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetIdeAutoCompletionSourceDirectoryGlobPatternsReturnsVendorPattern(): void
+    {
+        // Arrange
+        $developmentConfigMock = $this->createDevelopmentConfigMock([static::NAMESPACE_PYZ]);
+
+        // Act
+        $patterns = $developmentConfigMock->getIdeAutoCompletionSourceDirectoryGlobPatterns();
+
+        // Assert
+        $this->assertArrayHasKey(APPLICATION_VENDOR_DIR . '/*/*/src/', $patterns);
+        $this->assertSame('*/*/', $patterns[APPLICATION_VENDOR_DIR . '/*/*/src/']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetIdeAutoCompletionSourceDirectoryGlobPatternsReturnsSingleProjectNamespace(): void
+    {
+        // Arrange
+        $developmentConfigMock = $this->createDevelopmentConfigMock([static::NAMESPACE_PYZ]);
+
+        // Act
+        $patterns = $developmentConfigMock->getIdeAutoCompletionSourceDirectoryGlobPatterns();
+
+        // Assert
+        $expectedKey = APPLICATION_SOURCE_DIR . '/' . static::NAMESPACE_PYZ . '/';
+        $this->assertArrayHasKey($expectedKey, $patterns);
+        $this->assertSame('*/', $patterns[$expectedKey]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetIdeAutoCompletionSourceDirectoryGlobPatternsReturnsAllProjectNamespaces(): void
+    {
+        // Arrange
+        $projectNamespaces = [
+            static::NAMESPACE_PYZ,
+            static::NAMESPACE_SPRYKER_ACADEMY,
+            static::NAMESPACE_CUSTOM_PROJECT,
+        ];
+        $developmentConfigMock = $this->createDevelopmentConfigMock($projectNamespaces);
+
+        // Act
+        $patterns = $developmentConfigMock->getIdeAutoCompletionSourceDirectoryGlobPatterns();
+
+        // Assert
+        foreach ($projectNamespaces as $namespace) {
+            $expectedKey = APPLICATION_SOURCE_DIR . '/' . $namespace . '/';
+            $this->assertArrayHasKey(
+                $expectedKey,
+                $patterns,
+                sprintf('Expected pattern key for namespace "%s" not found.', $namespace),
+            );
+            $this->assertSame('*/', $patterns[$expectedKey]);
+        }
+
+        // Verify total count: 1 vendor pattern + N project namespace patterns
+        $this->assertCount(count($projectNamespaces) + 1, $patterns);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetIdeAutoCompletionSourceDirectoryGlobPatternsReturnsOnlyVendorPatternWhenNoProjectNamespaces(): void
+    {
+        // Arrange
+        $developmentConfigMock = $this->createDevelopmentConfigMock([]);
+
+        // Act
+        $patterns = $developmentConfigMock->getIdeAutoCompletionSourceDirectoryGlobPatterns();
+
+        // Assert
+        $this->assertCount(1, $patterns);
+        $this->assertArrayHasKey(APPLICATION_VENDOR_DIR . '/*/*/src/', $patterns);
+    }
+
+    /**
+     * @param array<string> $projectNamespaces
+     *
+     * @return \Spryker\Zed\Development\DevelopmentConfig|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function createDevelopmentConfigMock(array $projectNamespaces): DevelopmentConfig
+    {
+        $developmentConfigMock = $this->getMockBuilder(DevelopmentConfig::class)
+            ->onlyMethods(['get'])
+            ->getMock();
+
+        $developmentConfigMock
+            ->method('get')
+            ->willReturnCallback(function (string $key, $default = null) use ($projectNamespaces) {
+                if ($key === KernelConstants::PROJECT_NAMESPACES) {
+                    return $projectNamespaces;
+                }
+
+                return $default;
+            });
+
+        return $developmentConfigMock;
+    }
+}


### PR DESCRIPTION
## PR Description
Fix getIdeAutoCompletionSourceDirectoryGlobPatterns() to include all project namespaces configured in                             
  KernelConstants::PROJECT_NAMESPACES instead of only the single namespace from KernelConstants::PROJECT_NAMESPACE.                 
                                                                                                                                    
  Problem: Projects with multiple namespaces (e.g., Pyz, SprykerAcademy) only had the default namespace included in IDE             
  autocompletion sources. Classes in additional project namespaces were not recognized.                                             
                                                                                                                                    
  Solution: Iterate over all namespaces from KernelConstants::PROJECT_NAMESPACES array to ensure all configured project namespaces  
  are included in the IDE autocompletion source directories.  

## Steps before you submit a PR
- Please add tests for the code you add if it's possible.
- Please check out our contribution guide: https://docs.spryker.com/docs/dg/dev/code-contribution-guide.html
- Add a `contribution-license-agreement.txt` file with the following content:
`I hereby agree to Spryker's Contribution License Agreement in https://github.com/spryker/development/blob/HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH/CONTRIBUTING.md.`

This is a mandatory step to make sure you are aware of the license agreement and agree to it. `HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH` is a hash of the commit you are basing your branch from the master branch. You can take it from commits list of master branch before you submit a PR.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
